### PR TITLE
Fix undefined reference issues. 'RecordAWin' was spelled with a lowercase `w`.

### DIFF
--- a/cpp_programs/rockpaper.cpp
+++ b/cpp_programs/rockpaper.cpp
@@ -12,6 +12,7 @@ using namespace std;
 
 enum PlayType
 {
+	NONE,
 	ROCK,
 	PAPER,
 	SCISSORS
@@ -21,7 +22,7 @@ PlayType ConversionVal(char);
 void GetPlays(ifstream &, ifstream &, PlayType &, PlayType &, bool &);
 void PrintBigWinner(int, int);
 void ProcessPlays(int, PlayType, PlayType, int &, int &);
-void RecordAwin(char, int, int &);
+void RecordAWin(char, int, int &);
 
 int main()
 {
@@ -137,6 +138,9 @@ PlayType ConversionVal(/* in */ char someChar) // Play character
 	case 'S':
 		return SCISSORS;
 	}
+
+	// Invalid option
+	return NONE;
 }
 
 //********************************************************************
@@ -168,9 +172,9 @@ void ProcessPlays(/* in */ int gameNumber,	  // Game number
 	else if ((playForA == PAPER && playForB == ROCK) ||
 			 (playForA == SCISSORS && playForB == PAPER) ||
 			 (playForA == ROCK && playForB == SCISSORS))
-		RecordAwin('A', gameNumber, winsForA); // Player A wins
+		RecordAWin('A', gameNumber, winsForA); // Player A wins
 	else
-		RecordAwin('B', gameNumber, winsForB); // Player B wins
+		RecordAWin('B', gameNumber, winsForB); // Player B wins
 }
 
 //******************************************************************
@@ -210,8 +214,8 @@ void PrintBigWinner(/* in */ int winsForA, // A's win count
 
 {
 	cout << endl;
-	cout << "Player A has won " << winsForA << "games." << endl;
-	cout << "Player B has won " << winsForB << "games." << endl;
+	cout << "Player A has won " << winsForA << " games." << endl;
+	cout << "Player B has won " << winsForB << " games." << endl;
 	if (winsForA > winsForB)
 		cout << "Player A has won the most games." << endl;
 	else if (winsForB > winsForA)


### PR DESCRIPTION
Fixing 'rockpaper.cpp' compile issue. The problem was that the signature function `void RecordAWin(char, int, int &);` was written with a lowercase 'w', while the implementation was written with an uppercase 'W'. Changed both, as well as function calls, to uppercase 'W'.

I have also fixed a warning issue where ConversionVal had undefined behavior whether a value different than R, P or S was passed, even though a checks were made before the function call. Now the compiler will not complain about that.

Lastly, I have added an extra space to each player wins message, on 'games'. Before it would print 'Player X has won Ygames', and now it prints 'Player X has won Y games'.