### PR TITLE
Add '_CRT_SECURE_NO_WARNINGS' definition to matrixmath.c

### DIFF
--- a/c_programs/matrixmath.c
+++ b/c_programs/matrixmath.c
@@ -4,6 +4,10 @@
 // Time:   12:18:31
 // Brief:  This program that can convert C to F and F to C
 
+// Ignoring clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+// IntelliSense warning as the default compiler already uses C11
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
Added the `_CRT_SECURE_NO_WARNINGS`, as requested on issue #19 